### PR TITLE
[lua] Initial integration

### DIFF
--- a/projects/lua/Dockerfile
+++ b/projects/lua/Dockerfile
@@ -1,0 +1,45 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM sydr/ubuntu20.04-sydr-fuzz
+
+MAINTAINER Sergey Bronnikov
+
+# Install build dependencies.
+RUN apt-get update && apt-get install -y \
+	build-essential make coreutils sed \
+	autoconf automake libtool zlib1g-dev \
+	libreadline-dev libncurses5-dev libssl-dev \
+	libunwind-dev luajit wget curl
+
+# Clone target from GitHub.
+RUN git clone https://github.com/ligurio/lua-c-api-tests testdir
+
+WORKDIR testdir
+
+# Checkout specified commit. It could be updated later.
+RUN git checkout 017105bb03982f558e5111748bdfd44759699a79
+
+# Clone corpus from GitHub.
+RUN git clone --depth 1 https://github.com/ligurio/lua-c-api-corpus corpus
+
+# Copy build script and fuzz targets for libFuzzer and Sydr.
+COPY build.sh testdir/
+
+# Build fuzz targets.
+RUN testdir/build.sh
+
+WORKDIR /

--- a/projects/lua/README.md
+++ b/projects/lua/README.md
@@ -1,0 +1,108 @@
+# Lua
+
+[Lua][lua-homepage] is a powerful, efficient, lightweight, embeddable
+scripting language. Lua is dynamically typed, runs by interpreting bytecode
+with a register-based virtual machine, and has automatic memory management with
+incremental garbage collection, making it ideal for configuration, scripting,
+and rapid prototyping. Lua is designed, implemented, and maintained by a team
+at PUC-Rio, the Pontifical Catholic University of Rio de Janeiro in Brazil.
+
+## Build Docker
+
+    $ sudo docker build -t oss-sydr-fuzz-lua .
+
+## Run Hybrid Fuzzing
+
+Unzip Sydr (`sydr.zip`) in `projects/lua` directory:
+
+    $ unzip sydr.zip
+
+Run docker:
+
+    $ sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-lua /bin/bash
+
+Change directory to `/fuzz`:
+
+    # cd /fuzz
+
+Run hybrid fuzzing:
+
+    # sydr-fuzz -c luaL_loadstring.toml run
+
+Corpus minimization (step is required for AFL++):
+
+	sydr-fuzz -c luaL_loadstring.toml cmin
+
+Collect and report coverage:
+
+    # sydr-fuzz -c luaL_loadstring.toml cov-report
+
+Building HTML report:
+
+	$ sydr-fuzz -c luaL_loadstring.toml cov-show -- -format=html > index.html
+
+## Hybrid Fuzzing with AFL++
+
+    # sydr-fuzz -c luaL_loadstring-afl++.toml run
+
+## Alternative Fuzz Targets
+
+Lua project has 13 fuzz targets.
+
+### lua_dump
+
+    # sydr-fuzz -c lua_dump.toml run
+
+### luaL_addgsub
+
+    # sydr-fuzz -c luaL_addgsub.toml run
+
+### luaL_buffaddr
+
+    # sydr-fuzz -c luaL_buffaddr.toml run
+
+### luaL_bufflen
+
+    # sydr-fuzz -c luaL_bufflen.toml run
+
+### luaL_buffsub
+
+    # sydr-fuzz -c luaL_buffsub.toml run
+
+### luaL_dostring
+
+    # sydr-fuzz -c luaL_dostring.toml run
+
+### luaL_gsub
+
+    # sydr-fuzz -c luaL_gsub.toml run
+
+### luaL_loadbuffer
+
+    # sydr-fuzz -c luaL_loadbuffer.toml run
+
+### luaL_loadbuffer_proto
+
+    # sydr-fuzz -c luaL_loadbuffer_proto.toml run
+
+### luaL_loadbufferx
+
+    # sydr-fuzz -c luaL_loadbufferx.toml run
+
+### luaL_loadstring
+
+    # sydr-fuzz -c luaL_loadstring.toml run
+
+### lua_load
+
+    # sydr-fuzz -c lua_load.toml run
+
+### luaL_traceback
+
+    # sydr-fuzz -c luaL_traceback.toml run
+
+### lua_stringtonumber
+
+    # sydr-fuzz -c lua_stringtonumber.toml run
+
+[lua-homepage]: https://www.lua.org/about.html

--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -1,0 +1,229 @@
+#!/bin/bash -eu
+#
+# Copyright 2021 Google LLC
+# Modifications copyright (C) 2021 ISP RAS
+# Modifications copyright (C) 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+CC=clang
+CXX=clang++
+CFLAGS="-g -fsanitize=fuzzer-no-link,address,integer,bounds,null,undefined,float-divide-by-zero"
+CXXFLAGS="-g -fsanitize=fuzzer-no-link,address,integer,bounds,null,undefined,float-divide-by-zero"
+
+cd /testdir
+
+: ${LD:="${CXX}"}
+: ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
+
+cmake_args=(
+    -DUSE_LUA=ON
+    -DLUA_VERSION=e15f1f2bb7a38a3c94519294d031e48508d65006
+    -DOSS_FUZZ=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
+    -DCMAKE_BUILD_TYPE=Debug
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+
+# Build fuzzers.
+[[ -e build ]] && rm -rf build
+cmake "${cmake_args[@]}" -S . -B build -G Ninja
+cmake --build build --parallel
+
+# Archive and copy to $OUT seed corpus if the build succeeded.
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  corpus_dir="corpus/$module"
+  echo "Copying for $module";
+  cp $f /
+  [[ -e $corpus_dir ]] && cp -r $corpus_dir /corpus_$module
+done
+
+# Build the project for AFL++.
+CC=afl-clang-fast
+CXX=afl-clang-fast++
+CFLAGS="-g -fsanitize=fuzzer,address,integer,bounds,null,undefined,float-divide-by-zero"
+CXXFLAGS="-g -fsanitize=fuzzer,address,integer,bounds,null,undefined,float-divide-by-zero"
+
+cmake_args=(
+    -DUSE_LUA=ON
+    -DLUA_VERSION=e15f1f2bb7a38a3c94519294d031e48508d65006
+    -DOSS_FUZZ=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
+    -DCMAKE_BUILD_TYPE=Debug
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+[[ -e build ]] && rm -rf build
+mkdir -p build/tests
+cmake "${cmake_args[@]}" -S . -B build
+cmake --build build --parallel
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  echo "Copying for AFL++ $module";
+  cp $f /"$module"_afl
+done
+
+# Building cmplog instrumentation.
+export AFL_LLVM_CMPLOG=1
+cmake_args=(
+    -DUSE_LUA=ON
+    -DLUA_VERSION=e15f1f2bb7a38a3c94519294d031e48508d65006
+    -DOSS_FUZZ=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
+    -DCMAKE_BUILD_TYPE=Debug
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+[[ -e build ]] && rm -rf build
+mkdir -p build/tests
+cmake "${cmake_args[@]}" -S . -B build
+cmake --build build --parallel
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  echo "Copying for AFL++ $module";
+  cp $f /"$module"_cmplog
+done
+unset AFL_LLVM_CMPLOG
+
+# Build the project for Sydr.
+CC=clang
+CXX=clang++
+CFLAGS="-g"
+CXXFLAGS="-g"
+LDFLAGS=""
+
+cmake_args=(
+    -DUSE_LUA=ON
+    -DLUA_VERSION=e15f1f2bb7a38a3c94519294d031e48508d65006
+    -DOSS_FUZZ=ON
+    -DCMAKE_BUILD_TYPE=Debug
+    -DENABLE_ASAN=OFF
+    -DENABLE_UBSAN=OFF
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+[[ -e build ]] && rm -rf build
+mkdir -p build/tests
+# Workaround to build libprotobuf-mutator fuzz targets.
+# They crash with StandaloneFuzzTargetMain.c
+# So, we get libFuzzer without instrumentation.
+export LIB_FUZZING_ENGINE="-fsanitize=fuzzer"
+cmake "${cmake_args[@]}" -S . -B build
+cmake --build build --parallel
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  echo "Copying for Sydr $module";
+  cp $f /"$module"_sydr
+done
+
+# Build the project for llvm-cov.
+CFLAGS="-g -fprofile-instr-generate -fcoverage-mapping"
+CXXFLAGS="-g -fprofile-instr-generate -fcoverage-mapping"
+LDFLAGS=""
+
+cmake_args=(
+    -DUSE_LUA=ON
+    -DLUA_VERSION=e15f1f2bb7a38a3c94519294d031e48508d65006
+    -DOSS_FUZZ=ON
+    -DCMAKE_BUILD_TYPE=Debug
+    -DENABLE_ASAN=OFF
+    -DENABLE_UBSAN=OFF
+
+    # C compiler
+    -DCMAKE_C_COMPILER="${CC}"
+    -DCMAKE_C_FLAGS="${CFLAGS}"
+
+    # C++ compiler
+    -DCMAKE_CXX_COMPILER="${CXX}"
+    -DCMAKE_CXX_FLAGS="${CXXFLAGS}"
+
+    # Linker
+    -DCMAKE_LINKER="${LD}"
+    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_MODULE_LINKER_FLAGS="${LDFLAGS}"
+    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}"
+)
+[[ -e build ]] && rm -rf build
+mkdir -p build/tests
+cmake "${cmake_args[@]}" -S . -B build
+cmake --build build --parallel
+for f in $(find build/tests/ -name '*_test' -type f);
+do
+  name=$(basename $f);
+  module=$(echo $name | sed 's/_test//')
+  echo "Copying for llvm-cov $module";
+  cp $f /"$module"_cov
+done

--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -70,8 +70,9 @@ done
 # Build the project for AFL++.
 CC=afl-clang-fast
 CXX=afl-clang-fast++
-CFLAGS="-g -fsanitize=fuzzer,address,integer,bounds,null,undefined,float-divide-by-zero"
-CXXFLAGS="-g -fsanitize=fuzzer,address,integer,bounds,null,undefined,float-divide-by-zero"
+CFLAGS="-g -fsanitize=address,integer,bounds,null,undefined,float-divide-by-zero"
+CXXFLAGS="-g -fsanitize=address,integer,bounds,null,undefined,float-divide-by-zero"
+LDFLAGS=""
 
 cmake_args=(
     -DUSE_LUA=ON

--- a/projects/lua/luaL_addgsub_test-afl++.toml
+++ b/projects/lua/luaL_addgsub_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_addgsub_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_addgsub"
+target = "/luaL_addgsub_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_addgsub_cmplog -t 60000 -i /corpus_luaL_addgsub"
+target = "/luaL_addgsub_afl @@"
+
+[cov]
+target = "/luaL_addgsub_cov @@"

--- a/projects/lua/luaL_addgsub_test.toml
+++ b/projects/lua/luaL_addgsub_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_addgsub_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_addgsub_test"
+args = "/corpus_luaL_addgsub"
+
+[cov]
+target = "/luaL_addgsub_cov @@"

--- a/projects/lua/luaL_buffaddr_test-afl++.toml
+++ b/projects/lua/luaL_buffaddr_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_buffaddr_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_buffaddr"
+target = "/luaL_buffaddr_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_buffaddr_cmplog -t 60000 -i /corpus_luaL_buffaddr"
+target = "/luaL_buffaddr_afl @@"
+
+[cov]
+target = "/luaL_buffaddr_cov @@"

--- a/projects/lua/luaL_buffaddr_test.toml
+++ b/projects/lua/luaL_buffaddr_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_buffaddr_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_buffaddr_test"
+args = "/corpus_luaL_buffaddr"
+
+[cov]
+target = "/luaL_buffaddr_cov @@"

--- a/projects/lua/luaL_bufflen_test-afl++.toml
+++ b/projects/lua/luaL_bufflen_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_bufflen_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_bufflen"
+target = "/luaL_bufflen_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_bufflen_test_cmplog -t 60000 -i /corpus_luaL_bufflen"
+target = "/luaL_bufflen_test_afl @@"
+
+[cov]
+target = "/luaL_bufflen_test_cov @@"

--- a/projects/lua/luaL_bufflen_test.toml
+++ b/projects/lua/luaL_bufflen_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_bufflen_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_bufflen_test"
+args = "/corpus_luaL_bufflen"
+
+[cov]
+target = "/luaL_bufflen_cov @@"

--- a/projects/lua/luaL_buffsub_test-afl++.toml
+++ b/projects/lua/luaL_buffsub_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_buffsub_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_buffsub"
+target = "/luaL_buffsub_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_buffsub_cmplog -t 60000 -i /corpus_luaL_buffsub"
+target = "/luaL_buffsub_afl @@"
+
+[cov]
+target = "/luaL_buffsub_cov @@"

--- a/projects/lua/luaL_buffsub_test.toml
+++ b/projects/lua/luaL_buffsub_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_buffsub_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_buffsub_test"
+args = "/corpus_luaL_buffsub"
+
+[cov]
+target = "/luaL_buffsub_cov @@"

--- a/projects/lua/luaL_dostring_test-afl++.toml
+++ b/projects/lua/luaL_dostring_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_dostring_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_dostring"
+target = "/luaL_dostring_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_dostring_cmplog -t 60000 -i /corpus_luaL_dostring"
+target = "/luaL_dostring_afl @@"
+
+[cov]
+target = "/luaL_dostring_cov @@"

--- a/projects/lua/luaL_dostring_test.toml
+++ b/projects/lua/luaL_dostring_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_dostring_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_dostring_test"
+args = "/corpus_luaL_dostring"
+
+[cov]
+target = "/luaL_dostring_cov @@"

--- a/projects/lua/luaL_gsub_test-afl++.toml
+++ b/projects/lua/luaL_gsub_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_gsub_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_gsub"
+target = "/luaL_gsub_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_gsub_cmplog -t 60000 -i /corpus_luaL_gsub"
+target = "/luaL_gsub_afl @@"
+
+[cov]
+target = "/luaL_gsub_cov @@"

--- a/projects/lua/luaL_gsub_test.toml
+++ b/projects/lua/luaL_gsub_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_gsub_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_gsub_test"
+args = "/corpus_luaL_gsub"
+
+[cov]
+target = "/luaL_gsub_cov @@"

--- a/projects/lua/luaL_loadbuffer_proto_test-afl++.toml
+++ b/projects/lua/luaL_loadbuffer_proto_test-afl++.toml
@@ -1,0 +1,35 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbuffer_proto_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_loadbuffer_proto"
+target = "/luaL_loadbuffer_afl @@"
+[aflplusplus.env]
+AFL_MAP_SIZE = "10000000"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_loadbuffer_proto_cmplog -t 60000"
+target = "/luaL_loadbuffer_proto_afl @@"
+[aflplusplus.env]
+AFL_MAP_SIZE = "10000000"
+
+[cov]
+target = "/luaL_loadbuffer_proto_cov @@"

--- a/projects/lua/luaL_loadbuffer_proto_test.toml
+++ b/projects/lua/luaL_loadbuffer_proto_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbuffer_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_loadbuffer_test"
+args = "/corpus_luaL_loadbuffer"
+
+[cov]
+target = "/luaL_loadbuffer_cov @@"

--- a/projects/lua/luaL_loadbuffer_test-afl++.toml
+++ b/projects/lua/luaL_loadbuffer_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbuffer_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_loadbuffer"
+target = "/luaL_loadbuffer_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_loadbuffer_cmplog -t 60000 -i /corpus_luaL_loadbuffer"
+target = "/luaL_loadbuffer_afl @@"
+
+[cov]
+target = "/luaL_loadbuffer_cov @@"

--- a/projects/lua/luaL_loadbuffer_test.toml
+++ b/projects/lua/luaL_loadbuffer_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbuffer_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_loadbuffer_test"
+args = "/corpus_luaL_loadbuffer"
+
+[cov]
+target = "/luaL_loadbuffer_cov @@"

--- a/projects/lua/luaL_loadbufferx_test-afl++.toml
+++ b/projects/lua/luaL_loadbufferx_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbufferx_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_loadbufferx"
+target = "/luaL_loadbufferx_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_loadbufferx_cmplog -t 60000 -i /corpus_luaL_loadbufferx"
+target = "/luaL_loadbufferx_afl @@"
+
+[cov]
+target = "/luaL_loadbufferx_cov @@"

--- a/projects/lua/luaL_loadbufferx_test.toml
+++ b/projects/lua/luaL_loadbufferx_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadbufferx_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_loadbufferx_test"
+args = "/corpus_luaL_loadbufferx"
+
+[cov]
+target = "/luaL_loadbufferx_cov @@"

--- a/projects/lua/luaL_loadstring_test-afl++.toml
+++ b/projects/lua/luaL_loadstring_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadstring_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_loadstring"
+target = "/luaL_loadstring_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_loadstring_cmplog -t 60000 -i /corpus_luaL_loadstring"
+target = "/luaL_loadstring_afl @@"
+
+[cov]
+target = "/luaL_loadstring_cov @@"

--- a/projects/lua/luaL_loadstring_test.toml
+++ b/projects/lua/luaL_loadstring_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_loadstring_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_loadstring_test"
+args = "/corpus_luaL_loadstring"
+
+[cov]
+target = "/luaL_loadstring_cov @@"

--- a/projects/lua/luaL_traceback_test-afl++.toml
+++ b/projects/lua/luaL_traceback_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_traceback_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_luaL_traceback"
+target = "/luaL_traceback_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /luaL_traceback_cmplog -t 60000 -i /corpus_luaL_traceback"
+target = "/luaL_traceback_afl @@"
+
+[cov]
+target = "/luaL_traceback_cov @@"

--- a/projects/lua/luaL_traceback_test.toml
+++ b/projects/lua/luaL_traceback_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/luaL_traceback_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/luaL_traceback_test"
+args = "/corpus_luaL_traceback"
+
+[cov]
+target = "/luaL_traceback_cov @@"

--- a/projects/lua/lua_load_test-afl++.toml
+++ b/projects/lua/lua_load_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/lua_load_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_lua_load"
+target = "/lua_load_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /lua_load_cmplog -t 60000 -i /corpus_lua_load"
+target = "/lua_load_afl @@"
+
+[cov]
+target = "/lua_load_cov @@"

--- a/projects/lua/lua_load_test.toml
+++ b/projects/lua/lua_load_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/lua_load_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/lua_load_test"
+args = "/corpus_lua_load"
+
+[cov]
+target = "/lua_load_cov @@"

--- a/projects/lua/lua_stringtonumber_test-afl++.toml
+++ b/projects/lua/lua_stringtonumber_test-afl++.toml
@@ -1,0 +1,31 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/lua_stringtonumber_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_lua_stringtonumber"
+target = "/lua_stringtonumber_afl @@"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /lua_stringtonumber_cmplog -t 60000 -i /corpus_lua_stringtonumber"
+target = "/lua_stringtonumber_afl @@"
+
+[cov]
+target = "/lua_stringtonumber_cov @@"

--- a/projects/lua/lua_stringtonumber_test.toml
+++ b/projects/lua/lua_stringtonumber_test.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "-l debug -j 2"
+target = "/lua_stringtonumber_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/lua_stringtonumber_test"
+args = "/corpus_lua_stringtonumber"
+
+[cov]
+target = "/lua_stringtonumber_cov @@"


### PR DESCRIPTION
Patch adds initial fuzzers for PUC Rio Lua [^1].

- lua_dump, luaL_addgsub luaL_buffaddr, luaL_bufflen, luaL_buffsub, luaL_dostring, luaL_gsub, luaL_loadbuffer, luaL_loadbufferx, luaL_loadstring, lua_load, luaL_traceback, lua_stringtonumber.
- structure-aware test for luaL_loadbuffer with grammar defined in Protobuf.

[^1]: https://www.lua.org/