### PR TITLE
update zlib

### DIFF
--- a/projects/zlib/Dockerfile
+++ b/projects/zlib/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone  https://github.com/madler/zlib.git
 
 WORKDIR /zlib
 
-RUN git checkout 21767c654d31d2dccdde4330529775c6c5fd5389
+RUN git checkout 04f42ceca40f73e2978b50e93806c2a18c1281fc
 
 COPY afl.cc *.c* build.sh \
          ./

--- a/projects/zlib/example_flush_fuzzer.c
+++ b/projects/zlib/example_flush_fuzzer.c
@@ -85,9 +85,9 @@ int test_sync(unsigned char *compr, size_t comprLen, unsigned char *uncompr,
   CHECK_ERR(err, "inflateSync");
 
   err = inflate(&d_stream, Z_FINISH);
-  if (err != Z_DATA_ERROR) {
-    fprintf(stderr, "inflate should report DATA_ERROR\n");
-    /* Because of incorrect adler32 */
+  if (err != Z_DATA_ERROR && err != Z_STREAM_END) {
+    fprintf(stderr, "inflate should report DATA_ERROR or Z_STREAM_END\n");
+    /* v1.1.11= reports DATA_ERROR because of incorrect adler32. v1.1.12+ reports Z_STREAM END because it skips the adler32 check. */
     return 0;
   }
   err = inflateEnd(&d_stream);

--- a/projects/zlib/example_large_fuzzer.c
+++ b/projects/zlib/example_large_fuzzer.c
@@ -41,8 +41,8 @@ int test_large_deflate(unsigned char *compr, size_t comprLen,
   /* At this point, uncompr is still mostly zeroes, so it should compress
    * very well:
    */
-  c_stream.next_in = uncompr;
-  c_stream.avail_in = (unsigned int)uncomprLen;
+  c_stream.next_in = (Bytef *)data;
+  c_stream.avail_in = (unsigned int)dataLen;
   err = deflate(&c_stream, Z_NO_FLUSH);
   CHECK_ERR(err, "deflate large 1");
   if (c_stream.avail_in != 0) {

--- a/projects/zlib/example_large_fuzzer.c
+++ b/projects/zlib/example_large_fuzzer.c
@@ -41,8 +41,8 @@ int test_large_deflate(unsigned char *compr, size_t comprLen,
   /* At this point, uncompr is still mostly zeroes, so it should compress
    * very well:
    */
-  c_stream.next_in = (Bytef *)data;
-  c_stream.avail_in = (unsigned int)dataLen;
+  c_stream.next_in = uncompr;
+  c_stream.avail_in = (unsigned int)uncomprLen;
   err = deflate(&c_stream, Z_NO_FLUSH);
   CHECK_ERR(err, "deflate large 1");
   if (c_stream.avail_in != 0) {


### PR DESCRIPTION
1. В обёртке example_flush на текущей версии zlib имеется утечка памяти (в oss-fuzz исправлено), добавил исправление;
2. Обновил обёртку example_large
Sydr не ищет новые пути в example_large, т.к. обёртка использует только размер генерируемого файла.