### PR TITLE
Add xml2js

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Supported projects are located [here](projects). In addition to C/C++ projects S
 * Go: image-go;
 * Python: crunch, h5py, msgspec, pillow, pytorch-py, ruamel-yaml, tensorflow-py, ultrajson;
 * Java: hsqldb, json-sanitizer;
-* JavaScript: fast-xml-parser.
+* JavaScript: fast-xml-parser, node-xml2js.
 
 ## Contributing
 

--- a/projects/node-xml2js/Dockerfile
+++ b/projects/node-xml2js/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2024 ISP RAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM sydr/ubuntu20.04-sydr-fuzz
+
+# Install build dependencies.
+WORKDIR /jazzer.js
+RUN npm install xml2js
+ENV PATH=$PATH:/jazzer.js/fuzz/sydr
+
+# Clone target from GitHub.
+RUN git clone https://github.com/Leonidas-from-XIV/node-xml2js && \
+    cd node-xml2js && git checkout cf3e061e22e98152b88068c2345bc02581f4d6c7
+
+# Copy build script and targets.
+COPY fuzz.js node-xml2js/
+RUN chmod +x node-xml2js/fuzz.js
+
+# Prepare seed corpus and dict.
+COPY xml.dict /
+RUN git clone https://github.com/dvyukov/go-fuzz-corpus.git /go-fuzz-corpus
+RUN cp -r /go-fuzz-corpus/xml/corpus /corpus

--- a/projects/node-xml2js/README.md
+++ b/projects/node-xml2js/README.md
@@ -1,0 +1,37 @@
+# node-xml2js
+
+node-xml2js is a simple XML to JavaScript object converter that supports bi-directional conversion.
+
+## Build Docker
+
+    $ sudo docker build -t oss-sydr-fuzz-nodexml2js .
+
+## Run Fuzzing
+
+Unzip Sydr (`sydr.zip`) in `projects/node-xml2js` directory:
+
+    $ unzip sydr.zip
+
+Run docker (mount project directory to /jazzer.js subdirectory):
+
+    $ sudo docker run --cap-add=SYS_PTRACE  --security-opt seccomp=unconfined -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/jazzer.js/fuzz oss-sydr-fuzz-nodexml2js /bin/bash
+
+Change directory to `/jazzer.js/fuzz`:
+
+    # cd /jazzer.js/fuzz
+
+Run fuzzing:
+
+    # sydr-fuzz -c xml2js.toml run
+
+Minimize corpus:
+
+    # sydr-fuzz -c xml2js.toml cmin
+
+Collect and report coverage:
+
+    # sydr-fuzz -c xml2js.toml cov-html
+
+Analyze found bugs:
+
+    # sydr-fuzz -c xml2js.toml casr

--- a/projects/node-xml2js/fuzz.js
+++ b/projects/node-xml2js/fuzz.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env -S npx jazzer
+
+// Copyright 2023 Code Intelligence GmbH
+// Modifications copyright (C) 2024 ISP RAS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+// The code in this file is based on the examples available in JSFuzz:
+// https://gitlab.com/gitlab-org/security-products/analyzers/fuzzers/jsfuzz/-/blob/34a694a8c73bfe0895c4e24784ba5b6dfe964b94/examples/xml/fuzz.js
+// The original code is available under the Apache License 2.0.
+
+const { FuzzedDataProvider } = require('@jazzer.js/core');
+const xml2js = require("xml2js");
+
+/**
+ * @param { Buffer } data
+ */
+module.exports.fuzz = async function (data) { // async? --sync will have oom
+	const provider = new FuzzedDataProvider(data);
+    let xml = provider.consumeString(provider.consumeIntegralInRange(0, 2**48-1));
+
+    var options = {
+        attrkey: provider.consumeString(provider.consumeIntegralInRange(0, 2**48-1)),
+        charkey: provider.consumeString(provider.consumeIntegralInRange(0, 2**48-1)),
+        explicitCharkey: provider.consumeBoolean(),
+        trim: provider.consumeBoolean(),
+        normalizeTags: provider.consumeBoolean(),
+        normalize: provider.consumeBoolean(),
+        explicitRoot: provider.consumeNumber(),
+        emptyTag: provider.consumeString(provider.consumeIntegralInRange(0, 2**48-1)),
+        explicitArray: provider.consumeBoolean(),
+        ignoreAttrs: provider.consumeBoolean(),
+        mergeAttrs: provider.consumeBoolean(),
+        xmlns: provider.consumeBoolean(),
+        explicitChildren: provider.consumeBoolean(),
+        childkey: provider.consumeString(provider.consumeIntegralInRange(0, 2**48-1)),
+        preserveChildrenOrder: provider.consumeBoolean(),
+        charsAsChildren: provider.consumeBoolean(),
+        includeWhiteChars: provider.consumeBoolean(),
+        async: provider.consumeBoolean(),
+        strict: provider.consumeBoolean(),
+    };
+
+    var parser = new xml2js.Parser(options);
+    try {
+        parser.parseString(xml);
+        parser.parseStringPromise(xml).then(function () {}).catch(function () {});
+    } catch (error) {
+		if (!ignoredError(error)) throw error;
+	}
+};
+
+function ignoredError(error) {
+	return !!ignored.find((message) => error.message.startsWith(message));
+}
+
+const ignored = [
+	"Non-whitespace before first tag",
+	"Unencoded",
+	"Unexpected end",
+	"Invalid character",
+	"Invalid attribute name",
+	"Invalid tagname",
+	"Unclosed root tag",
+	"Attribute without value",
+	"Forward-slash in opening tag",
+	"Text data outside of root node",
+	"Unquoted attribute value",
+	"Unmatched closing tag",
+	"No whitespace between attributes",
+	"Unexpected close tag",
+];

--- a/projects/node-xml2js/xml.dict
+++ b/projects/node-xml2js/xml.dict
@@ -1,0 +1,87 @@
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+#
+# AFL dictionary for XML
+# ----------------------
+#
+# Several basic syntax elements and attributes, modeled on libxml2.
+#
+# Created by Michal Zalewski <lcamtuf@google.com>
+#
+
+attr_encoding=" encoding=\"1\""
+attr_generic=" a=\"1\""
+attr_href=" href=\"1\""
+attr_standalone=" standalone=\"no\""
+attr_version=" version=\"1\""
+attr_xml_base=" xml:base=\"1\""
+attr_xml_id=" xml:id=\"1\""
+attr_xml_lang=" xml:lang=\"1\""
+attr_xml_space=" xml:space=\"1\""
+attr_xmlns=" xmlns=\"1\""
+
+entity_builtin="&lt;"
+entity_decimal="&#1;"
+entity_external="&a;"
+entity_hex="&#x1;"
+
+string_any="ANY"
+string_brackets="[]"
+string_cdata="CDATA"
+string_col_fallback=":fallback"
+string_col_generic=":a"
+string_col_include=":include"
+string_dashes="--"
+string_empty="EMPTY"
+string_empty_dblquotes="\"\""
+string_empty_quotes="''"
+string_entities="ENTITIES"
+string_entity="ENTITY"
+string_fixed="#FIXED"
+string_id="ID"
+string_idref="IDREF"
+string_idrefs="IDREFS"
+string_implied="#IMPLIED"
+string_nmtoken="NMTOKEN"
+string_nmtokens="NMTOKENS"
+string_notation="NOTATION"
+string_parentheses="()"
+string_pcdata="#PCDATA"
+string_percent="%a"
+string_public="PUBLIC"
+string_required="#REQUIRED"
+string_schema=":schema"
+string_system="SYSTEM"
+string_ucs4="UCS-4"
+string_utf16="UTF-16"
+string_utf8="UTF-8"
+string_xmlns="xmlns:"
+
+tag_attlist="<!ATTLIST"
+tag_cdata="<![CDATA["
+tag_close="</a>"
+tag_doctype="<!DOCTYPE"
+tag_element="<!ELEMENT"
+tag_entity="<!ENTITY"
+tag_ignore="<![IGNORE["
+tag_include="<![INCLUDE["
+tag_notation="<!NOTATION"
+tag_open="<a>"
+tag_open_close="<a />"
+tag_open_exclamation="<!"
+tag_open_q="<?"
+tag_sq2_close="]]>"
+tag_xml_q="<?xml?>"

--- a/projects/node-xml2js/xml2js.toml
+++ b/projects/node-xml2js/xml2js.toml
@@ -1,0 +1,21 @@
+# Copyright 2024 ISP RAS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+exit-on-time = 3600
+
+[jazzer_js]
+path = "/jazzer.js/node-xml2js/fuzz.js"
+args = "-i=xml2js /corpus -- -workers=2 -jobs=100 -dict=/xml.dict"


### PR DESCRIPTION
node-xml2js is actually written in CoffeeScript, a language that compiles into JavaScript. Because of that we need to explicitly add `-i` option to capture source JS files from installed Node.js module