### PR TITLE
Update integration with PUC Rio Lua

### DIFF
--- a/projects/lua/Dockerfile
+++ b/projects/lua/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Sergey Bronnikov
+# Copyright 2023-2025 Sergey Bronnikov
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ RUN git clone https://github.com/ligurio/lua-c-api-tests testdir
 WORKDIR testdir
 
 # Checkout specified commit. It could be updated later.
-RUN git checkout f0b2821c0defc86b0755fc0cf96ad9386bfcfe44
+RUN git checkout dece9f2ad54ab2b117e00805010e389f5db0204c
 
 # Clone corpus from GitHub.
 RUN git clone --depth 1 https://github.com/ligurio/lua-c-api-corpus corpus
@@ -56,3 +56,5 @@ WORKDIR /
 # We comment this, because all of the afl++ fuzz targets are
 # failing due to invalid pointer pairs errors.
 # ENV ASAN_OPTIONS="detect_invalid_pointer_pairs=2"
+
+RUN find corpus_* -type f -empty | xargs rm

--- a/projects/lua/README.md
+++ b/projects/lua/README.md
@@ -47,7 +47,7 @@ Building HTML report:
 
 ## Alternative Fuzz Targets
 
-Lua project has 13 fuzz targets.
+Lua project has 15 fuzz targets.
 
 ### lua_dump
 
@@ -104,5 +104,9 @@ Lua project has 13 fuzz targets.
 ### lua_stringtonumber
 
     # sydr-fuzz -c lua_stringtonumber.toml run
+
+### torture
+
+    # sydr-fuzz -c torture.toml run
 
 [lua-homepage]: https://www.lua.org/about.html

--- a/projects/lua/build.sh
+++ b/projects/lua/build.sh
@@ -2,7 +2,7 @@
 #
 # Copyright 2021 Google LLC
 # Modifications copyright (C) 2021 ISP RAS
-# Modifications copyright (C) 2023 Sergey Bronnikov
+# Modifications copyright (C) 2023-2025 Sergey Bronnikov
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,9 +28,11 @@ cd /testdir
 : ${LD:="${CXX}"}
 : ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
 
+GIT_HASH=3dbb1a4b894c0744a331d4319d8d1704dc4ad943
+
 cmake_args=(
     -DUSE_LUA=ON
-    -DLUA_VERSION=6443185167c77adcc8552a3fee7edab7895db1a9
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
     -DENABLE_ASAN=ON
     -DENABLE_UBSAN=ON
@@ -65,7 +67,7 @@ do
   echo "Copying for $module";
   cp $f /
   [[ -e $corpus_dir ]] && cp -r $corpus_dir /corpus_$module
-  [[ -e $corpus_dir.dict ]] && cp $corpus_dir.dict /$module.dict
+  [[ -e ${corpus_dir}_test.dict ]] && cp ${corpus_dir}_test.dict /$module.dict
 done
 
 # Build the project for AFL++.
@@ -78,7 +80,7 @@ export AFL_LLVM_DICT2FILE=/afl++.dict
 export AFL_LLVM_DICT2FILE_NO_MAIN=1
 cmake_args=(
     -DUSE_LUA=ON
-    -DLUA_VERSION=6443185167c77adcc8552a3fee7edab7895db1a9
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
     -DENABLE_ASAN=ON
     -DENABLE_UBSAN=ON
@@ -116,7 +118,7 @@ unset AFL_LLVM_DICT2FILE_NO_MAIN
 export AFL_LLVM_CMPLOG=1
 cmake_args=(
     -DUSE_LUA=ON
-    -DLUA_VERSION=6443185167c77adcc8552a3fee7edab7895db1a9
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
     -DENABLE_ASAN=ON
     -DENABLE_UBSAN=ON
@@ -158,7 +160,7 @@ LDFLAGS=""
 
 cmake_args=(
     -DUSE_LUA=ON
-    -DLUA_VERSION=6443185167c77adcc8552a3fee7edab7895db1a9
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=ON
     -DCMAKE_BUILD_TYPE=Debug
     -DENABLE_ASAN=OFF
@@ -203,7 +205,7 @@ LDFLAGS=""
 
 cmake_args=(
     -DUSE_LUA=ON
-    -DLUA_VERSION=6443185167c77adcc8552a3fee7edab7895db1a9
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=ON
     -DCMAKE_BUILD_TYPE=Debug
     -DENABLE_ASAN=OFF

--- a/projects/lua/lua_dump_test-afl++.toml
+++ b/projects/lua/lua_dump_test-afl++.toml
@@ -1,0 +1,37 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/lua_dump_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_lua_dump -x /lua_dump.dict -x /afl++.dict"
+target = "/lua_dump_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /lua_dump_cmplog -t 60000 -i /corpus_lua_dump -x /lua_dump.dict -x /afl++.dict"
+target = "/lua_dump_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[cov]
+target = "/lua_dump_cov @@"

--- a/projects/lua/lua_dump_test-lf.toml
+++ b/projects/lua/lua_dump_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/lua_dump_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/lua_dump_test"
+args = "-dict=/lua_dump.dict /corpus_lua_dump"
+
+[cov]
+target = "/lua_dump_cov @@"

--- a/projects/lua/torture_test-afl++.toml
+++ b/projects/lua/torture_test-afl++.toml
@@ -1,0 +1,37 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/torture_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_torture -x /torture.dict -x /afl++.dict"
+target = "/torture_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /torture_cmplog -t 60000 -i /corpus_torture -x /torture.dict -x /afl++.dict"
+target = "/torture_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[cov]
+target = "/torture_cov @@"

--- a/projects/lua/torture_test-lf.toml
+++ b/projects/lua/torture_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/torture_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/torture_test"
+args = "-dict=/torture.dict /corpus_torture"
+
+[cov]
+target = "/torture_cov @@"


### PR DESCRIPTION
The patch updates integration with PUC Rio Lua project and brings the latest version of tests [1] to the sydr-oss-fuzz.

Part of #269

1. https://github.com/ligurio/lua-c-api-tests/commit/dece9f2ad54ab2b117e00805010e389f5db0204c