### PR TITLE
Update integration with LuaJIT

### DIFF
--- a/projects/luajit/Dockerfile
+++ b/projects/luajit/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 Sergey Bronnikov
+# Copyright 2023-2025 Sergey Bronnikov
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ RUN git clone https://github.com/ligurio/lua-c-api-tests testdir
 WORKDIR testdir
 
 # Checkout specified commit. It could be updated later.
-RUN git checkout f0b2821c0defc86b0755fc0cf96ad9386bfcfe44
+RUN git checkout dece9f2ad54ab2b117e00805010e389f5db0204c
 
 # Clone corpus from GitHub.
-RUN git clone --depth 1 https://github.com/ligurio/lua-c-api-corpus corpus
+RUN git clone --depth 1 --branch cfl https://github.com/ligurio/lua-c-api-corpus corpus
 
 # Copy build script and fuzz targets for libFuzzer and Sydr.
 COPY build.sh testdir/
@@ -41,3 +41,5 @@ COPY build.sh testdir/
 RUN testdir/build.sh
 
 WORKDIR /
+
+RUN find corpus_* -type d -exec rm -rf "{}" \;

--- a/projects/luajit/README.md
+++ b/projects/luajit/README.md
@@ -45,7 +45,7 @@ Building HTML report:
 
 ## Alternative Fuzz Targets
 
-LuaJIT project has 7 fuzz targets.
+LuaJIT project has 9 fuzz targets.
 
 ### lua_dump
 
@@ -78,5 +78,9 @@ LuaJIT project has 7 fuzz targets.
 ### luaL_traceback
 
     # sydr-fuzz -c luaL_traceback.toml run
+
+### torture
+
+    # sydr-fuzz -c torture.toml run
 
 [luajit-homepage]: http://luajit.org/

--- a/projects/luajit/build.sh
+++ b/projects/luajit/build.sh
@@ -2,7 +2,7 @@
 #
 # Copyright 2021 Google LLC
 # Modifications copyright (C) 2021 ISP RAS
-# Modifications copyright (C) 2023 Sergey Bronnikov
+# Modifications copyright (C) 2023-2025 Sergey Bronnikov
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,20 +20,22 @@
 
 CC=clang
 CXX=clang++
-CFLAGS="-g -fsanitize=fuzzer-no-link,address,integer,bounds,null,undefined,float-divide-by-zero"
-CXXFLAGS="-g -fsanitize=fuzzer-no-link,address,integer,bounds,null,undefined,float-divide-by-zero"
+CFLAGS="-g"
+CXXFLAGS="-g"
 
 cd /testdir
 
 : ${LD:="${CXX}"}
 : ${LDFLAGS:="${CXXFLAGS}"}  # to make sure we link with sanitizer runtime
 
+GIT_HASH=eec7a8016c3381b949b5d84583800d05897fa960
+
 cmake_args=(
     -DUSE_LUAJIT=ON
-    -DLUA_VERSION=ff6c496ba1b51ed360065cbc5259f62becd70daa
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
-    -DENABLE_ASAN=OFF
-    -DENABLE_UBSAN=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
     -DCMAKE_BUILD_TYPE=Debug
 
     # C compiler
@@ -61,7 +63,7 @@ for f in $(find build/tests/ -name '*_test' -type f);
 do
   name=$(basename $f);
   module=$(echo $name | sed 's/_test//')
-  corpus_dir="corpus/$module"
+  corpus_dir="corpus/corpus/${module}_test"
   echo "Copying for $module";
   cp $f /
   [[ -e $corpus_dir ]] && cp -r $corpus_dir /corpus_$module
@@ -79,10 +81,10 @@ export AFL_LLVM_DICT2FILE_NO_MAIN=1
 
 cmake_args=(
     -DUSE_LUAJIT=ON
-    -DLUA_VERSION=ff6c496ba1b51ed360065cbc5259f62becd70daa
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
-    -DENABLE_ASAN=OFF
-    -DENABLE_UBSAN=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
     -DCMAKE_BUILD_TYPE=Debug
 
     # C compiler
@@ -117,10 +119,10 @@ unset AFL_LLVM_DICT2FILE_NO_MAIN
 export AFL_LLVM_CMPLOG=1
 cmake_args=(
     -DUSE_LUAJIT=ON
-    -DLUA_VERSION=ff6c496ba1b51ed360065cbc5259f62becd70daa
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=OFF
-    -DENABLE_ASAN=OFF
-    -DENABLE_UBSAN=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
     -DCMAKE_BUILD_TYPE=Debug
 
     # C compiler
@@ -159,11 +161,11 @@ LDFLAGS=""
 
 cmake_args=(
     -DUSE_LUAJIT=ON
-    -DLUA_VERSION=ff6c496ba1b51ed360065cbc5259f62becd70daa
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=ON
     -DCMAKE_BUILD_TYPE=Debug
-    -DENABLE_ASAN=OFF
-    -DENABLE_UBSAN=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
 
     # C compiler
     -DCMAKE_C_COMPILER="${CC}"
@@ -204,11 +206,11 @@ LDFLAGS=""
 
 cmake_args=(
     -DUSE_LUAJIT=ON
-    -DLUA_VERSION=ff6c496ba1b51ed360065cbc5259f62becd70daa
+    -DLUA_VERSION="${GIT_HASH}"
     -DOSS_FUZZ=ON
     -DCMAKE_BUILD_TYPE=Debug
-    -DENABLE_ASAN=OFF
-    -DENABLE_UBSAN=OFF
+    -DENABLE_ASAN=ON
+    -DENABLE_UBSAN=ON
     -DENABLE_COV=ON
 
     # C compiler

--- a/projects/luajit/ffi_cdef_proto_test-afl++.toml
+++ b/projects/luajit/ffi_cdef_proto_test-afl++.toml
@@ -1,0 +1,37 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/ffi_cdef_proto_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_ffi_cdef_proto -x /ffi_cdef_proto.dict -x /afl++.dict"
+target = "/ffi_cdef_proto_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /ffi_cdef_proto_cmplog -t 60000 -i /corpus_ffi_cdef_proto -x /ffi_cdef_proto.dict -x /afl++.dict"
+target = "/ffi_cdef_proto_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[cov]
+target = "/ffi_cdef_proto_cov @@"

--- a/projects/luajit/ffi_cdef_proto_test-lf.toml
+++ b/projects/luajit/ffi_cdef_proto_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/ffi_cdef_proto_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/ffi_cdef_proto_test"
+args = "-dict=/ffi_cdef_proto.dict /corpus_ffi_cdef_proto"
+
+[cov]
+target = "/ffi_cdef_proto_cov @@"

--- a/projects/luajit/lua_dump_test-afl++.toml
+++ b/projects/luajit/lua_dump_test-afl++.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 Sergey Bronnikov
+# Copyright 2025 Sergey Bronnikov
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,22 @@
 
 [sydr]
 args = "--wait-jobs -s 90 -j2"
-target = "/luaL_dostring_sydr @@"
+target = "/lua_dump_sydr @@"
 jobs = 2
 
-[libfuzzer]
-path = "/luaL_dostring_test"
-args = "-dict=/luaL_dostring.dict /corpus_luaL_dostring"
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_lua_dump -x /lua_dump.dict -x /afl++.dict"
+target = "/lua_dump_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /lua_dump_cmplog -t 60000 -i /corpus_lua_dump -x /lua_dump.dict -x /afl++.dict"
+target = "/lua_dump_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
 
 [cov]
-target = "/luaL_dostring_cov @@"
+target = "/lua_dump_cov @@"

--- a/projects/luajit/lua_dump_test-lf.toml
+++ b/projects/luajit/lua_dump_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/lua_dump_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/lua_dump_test"
+args = "-dict=/lua_dump.dict /corpus_lua_dump"
+
+[cov]
+target = "/lua_dump_cov @@"

--- a/projects/luajit/lua_load_test-afl++.toml
+++ b/projects/luajit/lua_load_test-afl++.toml
@@ -16,16 +16,22 @@
 
 [sydr]
 args = "--wait-jobs -s 90 -j2"
-target = "/luaL_dostring_sydr @@"
+target = "/lua_load_sydr @@"
 jobs = 2
 
 [[aflplusplus]]
-args = "-t 60000 -i /corpus_luaL_dostring -x /luaL_dostring.dict -x /afl++.dict"
-target = "/luaL_dostring_afl @@"
+args = "-t 60000 -i /corpus_lua_load -x /lua_load.dict -x /afl++.dict"
+target = "/lua_load_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
 
 [[aflplusplus]]
-args = "-m none -l AT -c /luaL_dostring_cmplog -t 60000 -i /corpus_luaL_dostring -x /luaL_dostring.dict -x /afl++.dict"
-target = "/luaL_dostring_afl @@"
+args = "-m none -l AT -c /lua_load_cmplog -t 60000 -i /corpus_lua_load -x /lua_load.dict -x /afl++.dict"
+target = "/lua_load_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
 
 [cov]
-target = "/luaL_dostring_cov @@"
+target = "/lua_load_cov @@"

--- a/projects/luajit/lua_load_test-lf.toml
+++ b/projects/luajit/lua_load_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2023 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/lua_load_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/lua_load_test"
+args = "-dict=/lua_load.dict /corpus_lua_load"
+
+[cov]
+target = "/lua_load_cov @@"

--- a/projects/luajit/torture_test-afl++.toml
+++ b/projects/luajit/torture_test-afl++.toml
@@ -1,0 +1,37 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/torture_sydr @@"
+jobs = 2
+
+[[aflplusplus]]
+args = "-t 60000 -i /corpus_torture -x /torture.dict -x /afl++.dict"
+target = "/torture_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[[aflplusplus]]
+args = "-m none -l AT -c /torture_cmplog -t 60000 -i /corpus_torture -x /torture.dict -x /afl++.dict"
+target = "/torture_afl @@"
+[aflplusplus.env]
+ASAN_OPTIONS = "hard_rss_limit_mb=0,malloc_context_size=100"
+UBSAN_OPTIONS = "malloc_context_size=100"
+
+[cov]
+target = "/torture_cov @@"

--- a/projects/luajit/torture_test-lf.toml
+++ b/projects/luajit/torture_test-lf.toml
@@ -1,0 +1,27 @@
+# Copyright 2025 Sergey Bronnikov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+[sydr]
+args = "--wait-jobs -s 90 -j2"
+target = "/torture_sydr @@"
+jobs = 2
+
+[libfuzzer]
+path = "/torture_test"
+args = "-dict=/torture.dict /corpus_torture"
+
+[cov]
+target = "/torture_cov @@"


### PR DESCRIPTION
The patch updates integration with LuaJIT project and brings the latest version of tests [1] to the sydr-oss-fuzz.

Closes #269

1. ligurio/lua-c-api-tests@dece9f2