### PR TITLE
Refresh versions of dependencies and used command to avoid errors during build&use

### DIFF
--- a/projects/json-sanitizer/Dockerfile
+++ b/projects/json-sanitizer/Dockerfile
@@ -38,5 +38,5 @@ COPY DenylistFuzzer.java IdempotenceFuzzer.java ValidJsonFuzzer.java /
 ENV CASR_SOURCE_DIRS /json-sanitizer/src/main/java:/out/gson-2.8.6-src/
 
 WORKDIR /json-sanitizer
-RUN git checkout 6c86f9becc3412167e912384832722a5ebe69b12
+RUN git checkout fc612ab374de73d03864d56fb87b6a103b234489
 RUN /json-sanitizer/build.sh

--- a/projects/json-sanitizer/README.md
+++ b/projects/json-sanitizer/README.md
@@ -32,4 +32,4 @@ Minimize corpus:
 
 Collect and report coverage:
 
-    # sydr-fuzz -c DenylistFuzzer.toml cov-html -s /json-sanitizer/src/main/java
+    # sydr-fuzz -c DenylistFuzzer.toml cov-html

--- a/projects/json-sanitizer/build.sh
+++ b/projects/json-sanitizer/build.sh
@@ -18,11 +18,11 @@ SRC=/
 OUT=/out
 
 # Get maven
-wget https://dlcdn.apache.org/maven/maven-3/3.9.4/binaries/apache-maven-3.9.4-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz
 tar -xvf apache-maven-*-bin.tar.gz
 rm apache-maven-*-bin.tar.gz
 mv apache-maven-* /opt/
-export PATH="$PATH:/opt/apache-maven-3.9.4/bin"
+export PATH="$PATH:/opt/apache-maven-3.9.10/bin"
 
 # Build the json-sanitizer jar.
 export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
1. Rm deprecated arg -s for sydr-fuzz cov-html
2. update maven version from 3.9.4 to 3.9.10
3. update json-sanitizer source commit to newer one 