### PR TITLE
set lib version in npm install

### DIFF
--- a/projects/node-xml2js/Dockerfile
+++ b/projects/node-xml2js/Dockerfile
@@ -19,7 +19,7 @@ FROM $BASE_IMAGE
 
 # Install build dependencies.
 WORKDIR /jazzer.js
-RUN npm install xml2js
+RUN npm install xml2js@0.6.2
 ENV PATH=$PATH:/jazzer.js/fuzz/sydr
 
 # Clone target from GitHub.


### PR DESCRIPTION
set lib version that matches checkout commit version (it was matching before because there was no new updates)